### PR TITLE
Fix :  아바타와 맴버가 일대일관계로 되어있는 오류, 맴버테이블에 색상속성 누락 수정

### DIFF
--- a/src/main/java/com/linkode/api_server/domain/Avatar.java
+++ b/src/main/java/com/linkode/api_server/domain/Avatar.java
@@ -7,6 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -25,7 +28,13 @@ public class Avatar extends BaseTime {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private BaseStatus status;
 
-    @OneToOne(mappedBy = "avatar")
-    private Member member;
+    @OneToMany(mappedBy = "avatar")
+    private List<Member> members = new ArrayList<>();
+
+    public Avatar(Long avatarId, String avatarImg, BaseStatus status) {
+        this.avatarId = avatarId;
+        this.avatarImg = avatarImg;
+        this.status = status;
+    }
 
 }

--- a/src/main/java/com/linkode/api_server/domain/Member.java
+++ b/src/main/java/com/linkode/api_server/domain/Member.java
@@ -47,7 +47,7 @@ public class Member extends BaseTime {
 
 
     /** 캐릭터와의 연관관계의 주인 */
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "avatar_id")
     private Avatar avatar;
 

--- a/src/main/java/com/linkode/api_server/domain/Member.java
+++ b/src/main/java/com/linkode/api_server/domain/Member.java
@@ -32,6 +32,9 @@ public class Member extends BaseTime {
     @Column(nullable = false)
     private String nickname;
 
+    @Column(nullable = false)
+    private String color;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private BaseStatus status;
@@ -51,10 +54,11 @@ public class Member extends BaseTime {
     @JoinColumn(name = "avatar_id")
     private Avatar avatar;
 
-    public Member(Long memberId, String githubId, String nickname, BaseStatus status, Avatar avatar) {
+    public Member(Long memberId, String githubId, String nickname, String color,BaseStatus status, Avatar avatar) {
         this.memberId = memberId;
         this.githubId = githubId;
         this.nickname = nickname;
+        this.color=color;
         this.status = status;
         this.avatar = avatar;
     }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 아바타와 맴버테이블의 관계가 일대일이 아닌 일대다 관계여야하는데 오류가있어서 수정했습니다.
- [x] 맴버가 프로필을 설정할때 배경 색상도 함께 설정하는데  속성이 없어서 추가했습니다.

## 🔑 변경 사항 (Key Changes)

- 아바타와 맴버의 관계를 일대일에서 일대다로 수정

```diff 
+    @OneToMany(mappedBy = "avatar")
-    @OneToOne(mappedBy = "avatar")
+    private List<Member> members = new ArrayList<>();
-    private Member member ;
```

```diff 
+   @ManyToOne
-   @OneToOne
    @JoinColumn(name = "avatar_id")
    private Avatar avatar;
```
- 맴버 테이블에 색상 속성 추가
```diff 
+    @Column(nullable = false)
+    private String color;
```
## 📝 리뷰 요구사항 (To Reviewers)

- [x] 현재 구현된 아바타와 맴버의 관계를 일대다로 구현하는것이 비즈니스로직에 적합한지 컴토부탁드립니다.
- [x] 색상속성을 맴버테이블에 추가했는데 이 또한 논리적으로 적절한지 부탁드립니다.

## 확인 방법 

- 테이블이 정상적으로 생성되는것은 지난 PR에서 확인되었으니, 코드보다는 논리적흐름만 한번 더 검토해주시면 감사하겠습니다.
- local yml 파일의 datasource 에서 URL을 로컬 DB에 맞게 수정한뒤 테스트해주세요
