### PR TITLE
Feat : 스터디룸 수정

### DIFF
--- a/src/main/java/com/linkode/api_server/common/exception/StudyroomException.java
+++ b/src/main/java/com/linkode/api_server/common/exception/StudyroomException.java
@@ -1,0 +1,19 @@
+package com.linkode.api_server.common.exception;
+
+import com.linkode.api_server.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class StudyroomException extends RuntimeException{
+    private final ResponseStatus exceptionStatus;
+
+    public StudyroomException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public StudyroomException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/linkode/api_server/common/exception_handler/StudyroomExceptionControllerAdvice.java
+++ b/src/main/java/com/linkode/api_server/common/exception_handler/StudyroomExceptionControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.linkode.api_server.common.exception_handler;
+
+import com.linkode.api_server.common.exception.MemberException;
+import com.linkode.api_server.common.exception.StudyroomException;
+import com.linkode.api_server.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class StudyroomExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MemberException.class)
+    public BaseErrorResponse handle_StudyroomException(StudyroomException e) {
+        log.error("[handle_StudyroomException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/linkode/api_server/common/exception_handler/StudyroomExceptionControllerAdvice.java
+++ b/src/main/java/com/linkode/api_server/common/exception_handler/StudyroomExceptionControllerAdvice.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class StudyroomExceptionControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(MemberException.class)
+    @ExceptionHandler(StudyroomException.class)
     public BaseErrorResponse handle_StudyroomException(StudyroomException e) {
         log.error("[handle_StudyroomException]", e);
         return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());

--- a/src/main/java/com/linkode/api_server/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/linkode/api_server/common/response/status/BaseExceptionResponseStatus.java
@@ -11,8 +11,20 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
      */
     SUCCESS(1000,HttpStatus.OK.value(), "요청에 성공하였습니다."),
     FAILURE(2000, HttpStatus.BAD_REQUEST.value(), "요청에 실패하였습니다."),
-    INVALID_TOKEN(2000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
-    ALREADY_EXIST_MEMBER(3000, HttpStatus.OK.value(), "이미 존재하는 회원입니다.");
+    /**
+     * Token 관련 code : 3000 대
+     */
+    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
+    /**
+     * 멤버 관련 code : 4000 대
+     */
+    ALREADY_EXIST_MEMBER(4000, HttpStatus.OK.value(), "이미 존재하는 회원입니다."),
+    NOT_FOUND_MEMBERROLE(4001, HttpStatus.OK.value(), "해당 회원의 역할을 찾을 수 없습니다." ),
+    /**
+     * 스터디룸 관련 code : 5000 대
+     */
+    INVALID_ROLE(5000,HttpStatus.OK.value(), "해당 스터디룸에 접근할 권한이 없습니다."),
+    NOT_FOUND_STUDYROOM(5001,HttpStatus.OK.value(), "스터디룸을 찾을 수 없습니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/linkode/api_server/controller/StudyroomController.java
+++ b/src/main/java/com/linkode/api_server/controller/StudyroomController.java
@@ -4,6 +4,7 @@ import com.linkode.api_server.common.response.BaseResponse;
 import com.linkode.api_server.common.response.status.BaseExceptionResponseStatus;
 import com.linkode.api_server.dto.studyroom.CreateStudyroomRequest;
 import com.linkode.api_server.dto.studyroom.CreateStudyroomResponse;
+import com.linkode.api_server.dto.studyroom.PatchStudyroomRequest;
 import com.linkode.api_server.service.StudyroomService;
 import com.linkode.api_server.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +41,16 @@ public class StudyroomController {
         log.info("Success createStudyroom API");
         long memberId = jwtProvider.extractIdFromHeader(authorization);
         return studyroomService.createStudyroom(request, memberId);
+    }
+
+    /**
+     * 스터디룸 수정
+     */
+    @PatchMapping("")
+    public BaseResponse<Void> modifyStudyroom(@RequestHeader("Authorization") String authorization, @RequestBody PatchStudyroomRequest patchStudyroomRequest){
+        log.info("[StudyroomController.modifyStudyroom]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        studyroomService.modifyStudyroom(memberId,patchStudyroomRequest);
+        return new BaseResponse<>(null);
     }
 }

--- a/src/main/java/com/linkode/api_server/domain/Studyroom.java
+++ b/src/main/java/com/linkode/api_server/domain/Studyroom.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Studyroom extends BaseTime {
@@ -50,5 +49,10 @@ public class Studyroom extends BaseTime {
         this.studyroomName = studyroomName;
         this.studyroomProfile = studyroomProfile;
         this.status = status;
+    }
+
+    public void updateStudyroomInfo(String studyroomName, String studyroomProfile){
+        this.studyroomName = studyroomName;
+        this.studyroomProfile = studyroomProfile;
     }
 }

--- a/src/main/java/com/linkode/api_server/domain/Studyroom.java
+++ b/src/main/java/com/linkode/api_server/domain/Studyroom.java
@@ -8,12 +8,14 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Studyroom extends BaseTime {

--- a/src/main/java/com/linkode/api_server/dto/studyroom/PatchStudyroomRequest.java
+++ b/src/main/java/com/linkode/api_server/dto/studyroom/PatchStudyroomRequest.java
@@ -1,0 +1,19 @@
+package com.linkode.api_server.dto.studyroom;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PatchStudyroomRequest {
+    /**
+     * 스터디룸 수정
+     */
+    private Long studyroomId;
+    private String studyroomName;
+    private String studyroomImg;
+}

--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -23,5 +23,4 @@ public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom
     int deleteMemberStudyroom(long studyroomId);
 
     Optional<MemberStudyroom> findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(Long memberId, Long studyroomId, BaseStatus status);
-
 }

--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -1,5 +1,6 @@
 package com.linkode.api_server.repository;
 
+import com.linkode.api_server.domain.base.BaseStatus;
 import com.linkode.api_server.domain.memberstudyroom.MemberRole;
 import com.linkode.api_server.domain.memberstudyroom.MemberStudyroom;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,7 @@ public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom
     @Modifying
     @Query("UPDATE MemberStudyroom ms SET ms.status = 'DELETE' WHERE ms.studyroom.studyroomId = :studyroomId")
     int deleteMemberStudyroom(long studyroomId);
+
+    Optional<MemberStudyroom> findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(Long memberId, Long studyroomId, BaseStatus status);
+
 }

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -117,8 +117,6 @@ public class StudyroomService {
     public void modifyStudyroom(Long memberId, PatchStudyroomRequest patchStudyroomRequest){
         log.info("[StudyroomService.modifyStudyroom]");
         Long studyroomId = patchStudyroomRequest.getStudyroomId();
-        System.out.println("memberId: " + memberId);
-        System.out.println("studyroomId: " + studyroomId);
         MemberStudyroom memberStudyroom = memberstudyroomRepository.findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(studyroomId, memberId,BaseStatus.ACTIVE)
                 .orElseThrow(()->new StudyroomException(NOT_FOUND_MEMBERROLE));
         if(memberStudyroom.getRole().equals(MemberRole.CAPTAIN)){

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -122,12 +122,15 @@ public class StudyroomService {
         if(memberStudyroom.getRole().equals(MemberRole.CAPTAIN)){
             Studyroom studyroom = studyroomRepository.findById(studyroomId)
                     .orElseThrow(()-> new StudyroomException(NOT_FOUND_STUDYROOM));
+            String studyroomName = studyroom.getStudyroomName();
+            String studyroomImg = studyroom.getStudyroomProfile();
             if(patchStudyroomRequest.getStudyroomName() != null){
-                studyroom.setStudyroomName(patchStudyroomRequest.getStudyroomName());
+                studyroomName = patchStudyroomRequest.getStudyroomName();
             }
             if(patchStudyroomRequest.getStudyroomImg() != null){
-                studyroom.setStudyroomProfile(patchStudyroomRequest.getStudyroomImg());
+                studyroomImg = patchStudyroomRequest.getStudyroomImg();
             }
+            studyroom.updateStudyroomInfo(studyroomName,studyroomImg);
             studyroomRepository.save(studyroom);
         }else{
             throw new StudyroomException(INVALID_ROLE);

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -117,7 +117,7 @@ public class StudyroomService {
     public void modifyStudyroom(Long memberId, PatchStudyroomRequest patchStudyroomRequest){
         log.info("[StudyroomService.modifyStudyroom]");
         Long studyroomId = patchStudyroomRequest.getStudyroomId();
-        MemberStudyroom memberStudyroom = memberstudyroomRepository.findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(studyroomId, memberId,BaseStatus.ACTIVE)
+        MemberStudyroom memberStudyroom = memberstudyroomRepository.findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(memberId, studyroomId,BaseStatus.ACTIVE)
                 .orElseThrow(()->new StudyroomException(NOT_FOUND_MEMBERROLE));
         if(memberStudyroom.getRole().equals(MemberRole.CAPTAIN)){
             Studyroom studyroom = studyroomRepository.findById(studyroomId)


### PR DESCRIPTION
## 요약 (Summary)
- [x] 스터디룸의 이름, 사진을 수정하는 api 입니다.
- [x] Patch 메소드로 작성하여 수정이 필요한 부분만 수정하여 다시 저장하도록 구현하였습니다.

## 🔑 변경 사항 (Key Changes)
- `StudyroomException, StudyroomExceptionControllerAdvice 작성` : studyroom 에 대한 예외처리를 위한 코드 작성하였습니다.
- `BaseExceptionResponseStatus 스터디룸 예외 추가` : 5000번대에 스터디룸 관련 예외 추가하여 사용하였습니다.
- `PatchStudyroomRequest dto 작성` : [스터디룸 수정 api 명세서](https://flashy-calculator-39f.notion.site/693fb23fa7d94f94a35203a941f05456?pvs=4) dto 는 명세서 대로 작성하였습니다. response dto 는 불필요해서 작성하지 않았습니다.
- `StudyroomService.modifyStudyroom 작성` : memberId 와 studyroomId 로 JPA 를 이용해 기존에 이미 존재하고 있던 MemberStudyroom 객체를 불러와서 변경이 생긴 부분만 갱신해서 다시 저장하도록 구현하였습니다. 이 과정에서 MemberStudyroom domain 코드에 @Setter 어노테이션을 추가하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 명세서 대로 request 를 보냈을 때 워크벤치에서 잘 수정이 되는지
- [x] 예외 상황에서 제대로 된 예외가 발생하는지
- [x] request dto 가 전부 채워지지않고 일부만 채워진 상태에서도 잘 수정이 되는지
- [x] 만료된 토큰에 대한 예외처리가 터미널(?)에서는 보이는데 아직 postman 에서는 403 이 뜨고 아무런 json 응답이 반환되지 않습니다. 이 부분은 추후에 수정하도록 하겠습니다. 해당 api 에 대한 예외처리만 봐주시면 될 것 같습니다.

## 확인 방법 
❗️application-local.yml 파일에서 데이터베이스 설정이 자신의 로컬에 적절한 설정인지 확인부탁드립니다.
```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');

INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'jsilver01','User1','#FFFFF', 'ACTIVE');
INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'Mouon', '#FFFFF','User1', 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom 2', 'Profile for New Studyroom', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 1, 'CAPTAIN', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 2, 'CREW', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 1, 'CREW', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 2, 'CAPTAIN', 'ACTIVE');

```
위의 쿼리문을 실행시켜 주세요.
먼저, 로그인을 하고 엑세스 토큰을 발급받은 뒤에 해당 토큰을 헤더에 포함시켜서 `Patch` 메소드 테스트하시면 됩니다.
```
http://localhost:8080/studyroom
```

위의 쿼리문 기준으로 Mouon 은 studyroom = 1 에 대해서는 CREW 이므로 수정 권한이 없고, studyroom = 2 에 대해서는 수정이 문제없이 이루어져야 정상입니다.

<img width="388" alt="스크린샷 2024-07-06 오전 10 31 35" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/1dcf0ddc-5ba9-4ff7-b81b-4c1cc0091098">

<img width="652" alt="스크린샷 2024-07-06 오전 10 32 02" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/7afa5dfe-40ca-4ec7-aefb-5eea6e89fc9b">

<img width="372" alt="스크린샷 2024-07-06 오전 10 33 11" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/374b4f27-9265-4c5c-8c24-fb6e2def751c">

저는 2번 스터디룸에 대한 접근 권한이 없어서 다음과 같이 뜹니다.