### PR TITLE
Refactor : 삭제 API 수정

### DIFF
--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -16,7 +16,7 @@ public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom
 
     @Query("SELECT ms.role FROM MemberStudyroom ms WHERE ms.studyroom.studyroomId = :studyroomId AND ms.member.memberId = :memberId")
     Optional<MemberRole> findRoleByMemberIdAndStudyroomId(long studyroomId, long memberId);
-    @Transactional
+
     @Modifying
     @Query("UPDATE MemberStudyroom ms SET ms.status = 'DELETE' WHERE ms.studyroom.studyroomId = :studyroomId")
     int deleteMemberStudyroom(long studyroomId);

--- a/src/main/java/com/linkode/api_server/repository/StudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/StudyroomRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 @Repository
 @Transactional(readOnly = true)
 public interface StudyroomRepository extends JpaRepository<Studyroom, Long> {
-    @Transactional
     @Modifying
     @Query("UPDATE Studyroom sr SET sr.status = 'DELETE' WHERE sr.studyroomId = :studyroomId")
     int deleteStudyroom(long studyroomId);

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -29,6 +29,7 @@ public class StudyroomService {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Transactional
     public BaseExceptionResponseStatus deleteStudyroom(long studyroomId, long memberId) {
 
 
@@ -45,8 +46,7 @@ public class StudyroomService {
         MemberRole memberRole = optionalMemberRole.orElseThrow(() -> new IllegalArgumentException("Error because of Invalid Member Id or Invalid StudyRoom Id"));
 
         if (memberRole .equals(MemberRole.CAPTAIN)) {
-            if(studyroomRepository.deleteStudyroom(studyroomId)==1){
-                memberstudyroomRepository.deleteMemberStudyroom(studyroomId);
+            if(studyroomRepository.deleteStudyroom(studyroomId)==1 && memberstudyroomRepository.deleteMemberStudyroom(studyroomId)>0){
                 log.info("Success delete studyRoom in Service layer");
                 return BaseExceptionResponseStatus.SUCCESS;
             }else {


### PR DESCRIPTION
트랜잭션 범워 수정

## 요약 (Summary)
- [x] 두개의 쿼리리를 하나의 트랜잭션안에서 수행하도록 수정하였습니다.
- [x] 서비스계층의 조건 문도 추가하였습니다.
- [x] 말씀드린 쿼리 줄이기는 실패하였습니다..  

## 🔑 변경 사항 (Key Changes)

- MemberstudyroomRepository : deleteMemberStudyroom의 트랜잭션 어노테이션을 삭제하였습니다.
- StudyroomRepository : deleteStudyroom의 트랜잭션 어노테이션을 삭제하였습니다.
- StudyroomService : deleteStudyroom 트랜잭션 어노테이션을 추가하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 명세서 대로 반환되는지
   
<img width="570" alt="스크린샷 2024-07-06 오후 11 20 43" src="https://github.com/Linkode2024/Linkode2024_BE/assets/137624597/d29b0575-891f-41b4-b5b0-23c0696b81e9">

- [x] 스터디룸과 멤버 스터디룸 상태가 정상적으로 변경 되는지

## 확인 방법 
#### .yml을 자신의 로컬에맞게 변경하세요

쿼리문

```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img2.png', 'ACTIVE');

INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'Mouon', '두바이초콜릿','#FFFFF', 'ACTIVE');
INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'jsilver01', '애플코드','#FFFFF', 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom', 'Profile for New Studyroom', 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom 2', 'Profile for New Studyroom', 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom 3', 'Profile for New Studyroom', 'ACTIVE');


INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 1, 'CAPTAIN', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 2, 'CREW', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 3, 'CAPTAIN', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 1, 'CAPTAIN', 'ACTIVE');

SELECT * FROM member_studyroom WHERE studyroom_id=2 AND member_id=1;
SELECT * FROM member_studyroom;
SELECT * FROM studyroom;

```

소셜로그인 주소
```
https://github.com/login/oauth/authorize?client_id=Ov23liH7OLp2842PXbKI&scope=user:email
```


API 요청 주소 [PATCH}
```
http://localhost:8080/studyroom/removal?studyroomId=1
```
```
http://localhost:8080/studyroom/removal?studyroomId=2
```
```
http://localhost:8080/studyroom/removal?studyroomId=3
```

studyroomId=2 에서는 방장이 아니라 삭제되지 않아야합니다.
요청 실패 로그 메세지
<img width="1169" alt="스크린샷 2024-07-05 오전 1 06 48" src="https://github.com/Linkode2024/Linkode2024_BE/assets/137624597/10a73361-db52-44c6-bdcf-5ffb2935455b">


포스트맨 예시

<img width="1021" alt="스크린샷 2024-07-05 오전 12 14 10" src="https://github.com/Linkode2024/Linkode2024_BE/assets/137624597/fac20d53-38b3-4af1-ae9d-159d777802a2">

<img width="1021" alt="스크린샷 2024-07-05 오전 12 37 00" src="https://github.com/Linkode2024/Linkode2024_BE/assets/137624597/32eec856-918b-48d7-a326-3b67408f2eee">

<img width="1021" alt="스크린샷 2024-07-05 오전 12 55 48" src="https://github.com/Linkode2024/Linkode2024_BE/assets/137624597/a6aff7fd-ae33-4661-b851-ce6edc494b8c">

워크벤치에서 상태가 변한 모습
<img width="681" alt="스크린샷 2024-07-05 오전 12 56 36" src="https://github.com/Linkode2024/Linkode2024_BE/assets/137624597/ad29c499-8f86-4f6c-9ab2-8f5a71a595c7">