### PR TITLE
Feat : 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/com/linkode/api_server/common/exception/MemberStudyroomException.java
+++ b/src/main/java/com/linkode/api_server/common/exception/MemberStudyroomException.java
@@ -1,0 +1,20 @@
+package com.linkode.api_server.common.exception;
+
+import com.linkode.api_server.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class MemberStudyroomException extends RuntimeException{
+
+    private final ResponseStatus exceptionStatus;
+
+    public MemberStudyroomException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public MemberStudyroomException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/linkode/api_server/common/exception_handler/MemberStudyroomExceptionControllerAdvice.java
+++ b/src/main/java/com/linkode/api_server/common/exception_handler/MemberStudyroomExceptionControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.linkode.api_server.common.exception_handler;
+
+import com.linkode.api_server.common.exception.MemberException;
+import com.linkode.api_server.common.exception.MemberStudyroomException;
+import com.linkode.api_server.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class MemberStudyroomExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MemberStudyroomException.class)
+    public BaseErrorResponse handle_MemberStudyroomException(MemberStudyroomException e) {
+        log.error("[handle_MemberStudyroomException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/linkode/api_server/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/linkode/api_server/common/response/status/BaseExceptionResponseStatus.java
@@ -20,11 +20,17 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
      */
     ALREADY_EXIST_MEMBER(4000, HttpStatus.OK.value(), "이미 존재하는 회원입니다."),
     NOT_FOUND_MEMBERROLE(4001, HttpStatus.OK.value(), "해당 회원의 역할을 찾을 수 없습니다." ),
+    NOT_FOUND_MEMBER(4002, HttpStatus.OK.value(), "회원을 찾을 수 없습니다."),
     /**
      * 스터디룸 관련 code : 5000 대
      */
     INVALID_ROLE(5000,HttpStatus.OK.value(), "해당 스터디룸에 접근할 권한이 없습니다."),
-    NOT_FOUND_STUDYROOM(5001,HttpStatus.OK.value(), "스터디룸을 찾을 수 없습니다.");
+    NOT_FOUND_STUDYROOM(5001,HttpStatus.OK.value(), "스터디룸을 찾을 수 없습니다."),
+    /**
+     * 멤버_스터디룸 관련 code : 6000 대
+     */
+    NOT_FOUND_MEMBER_STUDYROOM(6000, HttpStatus.OK.value(), "조건에 맞는 멤버_스터디룸을 찾을 수 없습니다."),
+    NOT_FOUND_CREW(6001, HttpStatus.OK.value(), "해당 스터디룸의 CREW 를 찾을 수 없습니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/linkode/api_server/controller/MemberController.java
+++ b/src/main/java/com/linkode/api_server/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.linkode.api_server.controller;
 
 import com.linkode.api_server.common.response.BaseResponse;
-import com.linkode.api_server.common.response.status.BaseExceptionResponseStatus;
 import com.linkode.api_server.dto.member.CreateAvatarRequest;
 import com.linkode.api_server.service.MemberService;
 import com.linkode.api_server.util.JwtProvider;
@@ -29,6 +28,17 @@ public class MemberController {
     public BaseResponse<Void> createAvatar(@RequestBody CreateAvatarRequest createAvatarRequest) {
         log.info("[MemberController.createAvatar]");
         memberService.createAvatar(createAvatarRequest);
+        return new BaseResponse<>(null);
+    }
+
+    /**
+     * 회원탈퇴
+     */
+    @PatchMapping("")
+    public BaseResponse<Void> deleteMember(@RequestHeader("Authorization") String authorization){
+        log.info("[MemberController.deleteMember]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        memberService.deleteMember(memberId);
         return new BaseResponse<>(null);
     }
 

--- a/src/main/java/com/linkode/api_server/controller/MemberController.java
+++ b/src/main/java/com/linkode/api_server/controller/MemberController.java
@@ -40,6 +40,7 @@ public class MemberController {
         log.info("[MemberController.deleteMember]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         memberService.deleteMember(memberId);
+        return new BaseResponse<>(null);
     }
   
     /**

--- a/src/main/java/com/linkode/api_server/domain/Member.java
+++ b/src/main/java/com/linkode/api_server/domain/Member.java
@@ -18,7 +18,6 @@ import java.util.List;
 @AllArgsConstructor
 public class Member extends BaseTime {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -46,7 +45,6 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "member")
     private List<Data> dataList= new ArrayList<>();
 
-
     /** 캐릭터와의 연관관계의 주인 */
     @ManyToOne
     @JoinColumn(name = "avatar_id")
@@ -66,6 +64,10 @@ public class Member extends BaseTime {
         this.nickname = nickname;
         this.color = color;
         this.avatar = avatar;
+        this.status = status;
+    }
+
+    public void updateMemberStatus(BaseStatus status){
         this.status = status;
     }
 }

--- a/src/main/java/com/linkode/api_server/domain/Studyroom.java
+++ b/src/main/java/com/linkode/api_server/domain/Studyroom.java
@@ -1,6 +1,7 @@
 package com.linkode.api_server.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ser.Serializers;
 import com.linkode.api_server.domain.base.BaseStatus;
 import com.linkode.api_server.domain.base.BaseTime;
 import com.linkode.api_server.domain.memberstudyroom.MemberStudyroom;
@@ -54,5 +55,9 @@ public class Studyroom extends BaseTime {
     public void updateStudyroomInfo(String studyroomName, String studyroomProfile){
         this.studyroomName = studyroomName;
         this.studyroomProfile = studyroomProfile;
+    }
+
+    public void updateStudyroomStatus(BaseStatus status){
+        this.status = status;
     }
 }

--- a/src/main/java/com/linkode/api_server/domain/base/BaseTime.java
+++ b/src/main/java/com/linkode/api_server/domain/base/BaseTime.java
@@ -5,7 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -19,7 +19,7 @@ public class BaseTime {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedBy
+    @LastModifiedDate
     private LocalDateTime modifiedAt;
 
 }

--- a/src/main/java/com/linkode/api_server/domain/memberstudyroom/MemberStudyroom.java
+++ b/src/main/java/com/linkode/api_server/domain/memberstudyroom/MemberStudyroom.java
@@ -40,4 +40,8 @@ public class MemberStudyroom extends BaseTime {
     @JoinColumn(name = "studyroom_id")
     private Studyroom studyroom;
 
+    public void updateMemberStudyroomStatus(BaseStatus status){
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/linkode/api_server/repository/MemberRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    boolean existsByGithubIdAndStatus(String githubId, BaseStatus ACTIVE);
-    Optional<Member> findByGithubIdAndStatus(String githubId, BaseStatus ACTIVE);
+    boolean existsByGithubIdAndStatus(String githubId, BaseStatus status);
+    Optional<Member> findByGithubIdAndStatus(String githubId, BaseStatus status);
+    Optional<Member> findByMemberIdAndStatus(Long memberId, BaseStatus status);
 }

--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -6,12 +6,13 @@ import com.linkode.api_server.domain.memberstudyroom.MemberStudyroom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @Transactional(readOnly = true)
@@ -26,5 +27,12 @@ public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom
 
     Optional<MemberStudyroom> findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(Long memberId, Long studyroomId, BaseStatus status);
     Optional<List<MemberStudyroom>> findByMember_MemberIdAndStatus(Long memberId, BaseStatus status);
-    Optional<List<MemberStudyroom>> findByStudyroom_StudyroomIdAndStatus(Long studyroomId, BaseStatus status);
+    Optional<List<MemberStudyroom>> findByStudyroom_StudyroomIdInAndStatus(Set<Long> studyroomIds, BaseStatus status);
+    @Modifying
+    @Query("UPDATE Studyroom s SET s.status = :status WHERE s.studyroomId IN :studyroomIds")
+    void updateStudyroomStatus(@Param("studyroomIds") Set<Long> studyroomIds, @Param("status") BaseStatus status);
+
+    @Modifying
+    @Query("UPDATE MemberStudyroom ms SET ms.status = :status WHERE ms IN :memberStudyrooms")
+    void updateMemberStudyroomStatus(@Param("memberStudyrooms") List<MemberStudyroom> memberStudyrooms, @Param("status") BaseStatus status);
 }

--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.swing.text.html.Option;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -23,4 +25,6 @@ public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom
     int deleteMemberStudyroom(long studyroomId);
 
     Optional<MemberStudyroom> findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(Long memberId, Long studyroomId, BaseStatus status);
+    Optional<List<MemberStudyroom>> findByMember_MemberIdAndStatus(Long memberId, BaseStatus status);
+    Optional<List<MemberStudyroom>> findByStudyroom_StudyroomIdAndStatus(Long studyroomId, BaseStatus status);
 }

--- a/src/main/java/com/linkode/api_server/service/MemberService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.ALREADY_EXIST_MEMBER;
+import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_MEMBER;
 
 @Slf4j
 @Service
@@ -22,6 +23,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final AvatarRepository avatarRepository;
+    private final MemberStudyroomService memberStudyroomService;
+    private final TokenService tokenService;
 
     /**
      * 캐릭터 생성(회원가입)
@@ -42,5 +45,22 @@ public class MemberService {
             Member member = new Member(githubId, nickname, avatar, color, BaseStatus.ACTIVE);
             memberRepository.save(member);
         }
+    }
+
+    /**
+     * 회원탈퇴
+     */
+    @Transactional
+    public void deleteMember(Long memberId){
+        log.info("[MemberService.deleteMember]");
+        Member member = memberRepository.findByMemberIdAndStatus(memberId, BaseStatus.ACTIVE)
+                .orElseThrow(()-> new MemberException(NOT_FOUND_MEMBER));
+        memberStudyroomService.deleteMember(memberId); // member_studyroom 테이블에서 상태 delete 작업 수행
+        member.updateMemberStatus(BaseStatus.DELETE); // member 테이블에서 상태 delete 작업 수행
+        memberRepository.save(member);
+        tokenService.invalidateRefreshToken(member.getMemberId());
+        /**
+         * TODO : 자료실 delete 작업 -> 아직 자료실이 없어서 구현 불가 추후에 작업
+         */
     }
 }

--- a/src/main/java/com/linkode/api_server/service/MemberService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberService.java
@@ -58,7 +58,7 @@ public class MemberService {
         memberStudyroomService.deleteMember(memberId); // member_studyroom 테이블에서 상태 delete 작업 수행
         member.updateMemberStatus(BaseStatus.DELETE); // member 테이블에서 상태 delete 작업 수행
         memberRepository.save(member);
-        tokenService.invalidateRefreshToken(member.getMemberId());
+        tokenService.invalidateToken(member.getGithubId());
         /**
          * TODO : 자료실 delete 작업 -> 아직 자료실이 없어서 구현 불가 추후에 작업
          */

--- a/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
@@ -1,0 +1,59 @@
+package com.linkode.api_server.service;
+
+import com.linkode.api_server.common.exception.MemberStudyroomException;
+import com.linkode.api_server.domain.Studyroom;
+import com.linkode.api_server.domain.base.BaseStatus;
+import com.linkode.api_server.domain.memberstudyroom.MemberRole;
+import com.linkode.api_server.domain.memberstudyroom.MemberStudyroom;
+import com.linkode.api_server.repository.MemberstudyroomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_CREW;
+import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_MEMBER_STUDYROOM;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberStudyroomService {
+
+    private final MemberstudyroomRepository memberstudyroomRepository;
+
+    /**
+     * 회원 탈퇴
+     */
+    @Transactional
+    public void deleteMember(Long memerId){
+
+        log.info("[MemberStudyroomService.deleteMember]");
+
+        List<MemberStudyroom> memberStudyroomList = memberstudyroomRepository.findByMember_MemberIdAndStatus(memerId, BaseStatus.ACTIVE)
+                .orElseThrow(()-> new MemberStudyroomException(NOT_FOUND_MEMBER_STUDYROOM));
+
+        for(MemberStudyroom memberStudyroom : memberStudyroomList) {
+            if(memberStudyroom.getRole() == MemberRole.CAPTAIN){
+                log.info("[MemberStudyroomService.deleteMember.CAPTAIN_VERSION]");
+                Long studyroomId = memberStudyroom.getStudyroom().getStudyroomId();
+                // 지우려는 스터디룸에 포함된 crew 들도 delete
+                List<MemberStudyroom> crewList = memberstudyroomRepository.findByStudyroom_StudyroomIdAndStatus(studyroomId, BaseStatus.ACTIVE)
+                        .orElseThrow(()-> new MemberStudyroomException(NOT_FOUND_CREW));
+                for(MemberStudyroom crew : crewList){
+                    log.info("[[MemberStudyroomService.deleteMember.CAPTAIN_VERSION.crewDelete]");
+                    crew.updateMemberStudyroomStatus(BaseStatus.DELETE);
+                    memberstudyroomRepository.save(crew);
+                }
+                //스터디룸도 delete
+                memberStudyroom.getStudyroom().updateStudyroomStatus(BaseStatus.DELETE);
+                memberstudyroomRepository.save(memberStudyroom);
+            }else{
+                log.info("[MemberStudyroomService.deleteMember.CREW_VERSION]");
+                memberStudyroom.updateMemberStudyroomStatus(BaseStatus.DELETE);
+                memberstudyroomRepository.save(memberStudyroom);
+            }
+        }
+    }
+}

--- a/src/main/java/com/linkode/api_server/service/TokenService.java
+++ b/src/main/java/com/linkode/api_server/service/TokenService.java
@@ -19,7 +19,7 @@ public class TokenService {
 
     public void storeToken(String token, String githubId) {
         // redis 에 토큰 저장
-        redisTemplate.opsForValue().set(token, githubId, refreshTokenExpiration, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set(githubId, token, refreshTokenExpiration, TimeUnit.MILLISECONDS);
     }
 
     public boolean checkTokenExists(String token) {
@@ -28,8 +28,8 @@ public class TokenService {
         return result != null && result;
     }
 
-    public void invalidateToken(String token) {
+    public void invalidateToken(String githubId) {
         // redis 에서 토큰 삭제
-        redisTemplate.delete(token);
+        redisTemplate.delete(githubId);
     }
 }

--- a/src/main/java/com/linkode/api_server/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/linkode/api_server/util/JwtAuthenticationFilter.java
@@ -1,11 +1,13 @@
 package com.linkode.api_server.util;
 
 import com.linkode.api_server.domain.Member;
+import com.linkode.api_server.service.TokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
@@ -21,34 +23,41 @@ import java.util.Optional;
 @Order(0)
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
+    private final TokenService tokenService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = parseBearerToken(request);
-        Member member = parseUserSpecification(token);
-        AbstractAuthenticationToken authenticated = new UsernamePasswordAuthenticationToken(member, null, null);
-        authenticated.setDetails(new WebAuthenticationDetails(request));
-        SecurityContextHolder.getContext().setAuthentication(authenticated);
+
+        if (token != null) {
+            try {
+                log.info(token);
+                String githubId = jwtProvider.extractGithubIdFromToken(token);
+                if (tokenService.checkTokenExists(githubId)) { // 리프레시 토큰이 존재하는지 확인
+                    Member member = new Member(null, githubId, "", "", null, null);
+                    AbstractAuthenticationToken authenticated = new UsernamePasswordAuthenticationToken(member, null, null);
+                    authenticated.setDetails(new WebAuthenticationDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authenticated);
+                } else {
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+                    return;
+                }
+            } catch (Exception e) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+                return;
+            }
+        }
 
         filterChain.doFilter(request, response);
     }
 
     private String parseBearerToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
-                .filter(token -> token.substring(0, 7).equalsIgnoreCase("Bearer "))
+                .filter(token -> token.startsWith("Bearer "))
                 .map(token -> token.substring(7))
                 .orElse(null);
-    }
-
-    private Member parseUserSpecification(String token) {
-        String[] split = Optional.ofNullable(token)
-                .filter(subject -> subject.length() >= 10)
-                .map(jwtProvider::validateTokenAndGetSubject)
-                .orElse("anonymous:ANONYMOUS")
-                .split(":");
-
-        return new Member(null, split[0], "", "", null, null);
     }
 }

--- a/src/main/java/com/linkode/api_server/util/JwtProvider.java
+++ b/src/main/java/com/linkode/api_server/util/JwtProvider.java
@@ -121,4 +121,14 @@ public class JwtProvider {
 
         return memberId;
     }
+    // Access Token에서 githubId 추출
+    public String extractGithubIdFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 회원탈퇴 API 구현하였습니다.
- [x] 회원이 탈퇴하면 해당 회원과 관련된 모든 데이터들이 DELETE 처리됩니다.
- [x]  레디스에서 해당 회원의 깃허브 아이디(키값) 으로 리프레시 토큰값을 찾아, 레디스에서 삭제함으로 토큰에 대한 유효성을 만료시켰습니다.
- [x] request, response dto 는 필요하지 않아서 생성하지 않았습니다. [회원탈퇴 api 명세서](https://flashy-calculator-39f.notion.site/c676935ecd9a440e8a0d21e29a688d54?pvs=4) 

## 🔑 변경 사항 (Key Changes)
- `JwtAuthenticationFilter 수정` : 해당 코드에 api 요청이 들어왔을 때, 토큰이 레디스에 있는지 확인하는 부분이 누락되어 있어, 추가하였습니다. 구현된 코드에서 토큰을 발급할 때에 subject 로 githubId 를 사용하고 claim 으로 memberId 를 사용합니다. 따라서 두가지 값을 모두 추출할 수 있고, 저는 레디스에 String 값인 githubId 를 키값으로 리프레시토큰을 value 로 저장하기 때문에 githubId 를 추출하여 레디스에서 찾는 쪽으로 구현하였습니다. 만약에 레디스에서 사용자를 찾을 수 없다면 403 forbidden 으로 막히게 됩니다. 
- `TokenService 수정` : 이전 코드에서는 token 으로 레디스에서 삭제하는 코드들이었는데, 위에서 말했듯이 레디스에 키 : gitbhuId, 값 : refreshToken 이렇게 저장하기 때문에 키값으로 찾으려면 파라미터 값이 token -> githubId 로 변경되어야했습니다. 따라서 파라미터로 받는 값을 수정하였습니다. 즉, 깃허브 아이디로 레디스를 찾는다고 보면 됩니다.
- `JwtProvider 메소드 추가` : JwtProvider 에 엑세스토큰에서 githubId 를 추출하는 메소드 추가하였습니다.
- `MemberController.deleteMember 작성` : 컨트롤러에 회원 탈퇴를 처리하는 컨트롤러 작성하였습니다. 
- `Member, Studyroom, MemberStudyroom 도메인 수정` : 도메인 코드에 updateStatus 메소드 추가하였습니다. status 를 DELETE 로 변경하기 위해 추가하였습니다.
- `BaseTime 수정` : 구현 중 modified_at 필드가 업데이트 되지 않는 오류 발견해서 확인하던 중에 어노테이션이 @ModifiedBy 로 잘못들어가 있는 것을 확인해서 @ModifiedDate 로 수정하였습니다.
- `MemberService.deleteMember 작성` : 회원탈퇴를 위한 서비스 코드입니다. memberStudyroomService 에 member_studyroom 에 관련된 데이터들의 delete 처리를 넘겼습니다. member 테이블에서 해당 사용자의 status 를 DELETE 로 업데이트하였고, tokenService.invalidateToken 를 사용하여 레디스에서 지우는 작업도 수행하였습니다. 아직 자료실이 구현되지 않아 탈퇴하는 회원의 자료 처리가 안되어있습니다. 추후에 추가로 수정하도록 하겠습니다.
- `MemberStudyroomService.deleteMember 작성`: 회원탈퇴를 하는 회원의 역할(CAPTAIN/CREW) 에 따라 다르게 처리하도록 구현하였습니다. 만약 CAPTAIN 이라면 해당 스터디룸 또한 DELETE 처리하고, 스터디룸에 속한 다른 사용자의 데이터도 DELETE 처리하였습니다. (스터디룸이 사라져버렸으니, 빈 스터디룸에는 사용자가 ACTIVE 한 상태일 수 없습니다.) 만약 CREW 라면 단순히 사용자만 DELETE 처리하였습니다.  
- `exception 추가` : 적절한 예외처리를 위해 exception 추가하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 멤버를 Member 테이블에서 DELETE 처리 하는지
- [x] 멤버가 만약 CAPTAIN 이라면 해당 스터디룸을 DELETE 처리하고, Member_Studyroom 테이블에서 삭제 처리된 스터디룸의 id 를 가진 데이터들 또한 DELETE 처리 되는지
- [x] 멤버가 만약 CREW 라면, 스터디룸과 다른 데이터들은 건들지 않고 오직 자기 자신만 Member_Studyroom 테이블에서 삭제 처리하는지
- [x] 로그인하면, 레디스에 깃허브 아이디로 잘 들어가는지 (`keys *` 로 확인가능 -> 혹시 키값으로 확인하는 방법은 까먹으셨다면 이전 pr 에서 맥에 레디스 까는 법에 대한 링크를 참고해주세요!)
- [x] 회원 탈퇴 api 를 실행시키고 다시 레디스를 확인해봤을 때 데이터가 잘 지워졌는지
- [x] 데이터가 지워진 것을 확인하고, 지워진 사용자의 엑세스토큰을 헤더에 포함시켜 다른 api 를 호출하였을 때 403 이 반환되는지

## 확인 방법 
❗️application-local.yml 파일의 데이터베이스 설정을 로컬에 맞췄는지 확인해주세요.

먼저 코드를 실행시키고 레디스도 실행시켜주세요.
`redis-cli` 를 입력하고 `keys *`를 입력했을 때 (empty array) 라면 바로 아래의 쿼리문을 실행시키고, 만약 데이터가 존재한다면 `FLUSHDB` 을 입력하여 초기화해 주세요.

```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');

INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'Mouon', '두바이초콜릿','#FFFFF', 'ACTIVE');
INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'jsilver01', '애플코드','#FFFFF', 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom 2', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom 3', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom 4', 'Profile for New Studyroom', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 1, 'CAPTAIN', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 2, 'CREW', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 3, 'CAPTAIN', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 4, 'CREW', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 1, 'CREW', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 2, 'CAPTAIN', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 3, 'CREW', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 4, 'CAPTAIN', 'ACTIVE');

```

이 쿼리문을 실행시켜주세요.
그 다음 로그인을 진행해주세요.
레디스에서 다시 `keys *` 를 입력하고 깃허브 id 로 키값이 들어간 것을 확인해주세요.
그 다음 PATCH 메소드로 아래의 요청을 보내주세요. 헤더에는 로그인에서 받은 "엑세스" 토큰을 넣어서 보내주세요.

```
http://localhost:8080/user
```
<img width="270" alt="스크린샷 2024-07-08 오전 12 30 58" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/540f8f64-3239-494a-8f42-311faaf72ef8">

로그인 후 레디스에 저장된 모습입니다.

<img width="448" alt="스크린샷 2024-07-08 오전 12 26 23" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/54a42b78-2e7b-48b1-82fe-aa12ab10b458">

요청에 성공하면 데이터베이스로 들어가서 값들이 잘 처리되었는지 확인해주세요.

<img width="448" alt="스크린샷 2024-07-08 오전 12 27 05" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/6e805189-4681-4d53-ac55-c30f41524658">

<img width="448" alt="스크린샷 2024-07-08 오전 12 27 27" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/2621fe17-32b6-49b5-b6b2-898170221a12">

<img width="563" alt="스크린샷 2024-07-08 오전 12 27 51" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/42b56e0a-585b-4ca9-a66b-352971313fb5">

<img width="165" alt="스크린샷 2024-07-08 오전 12 29 07" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/ac2ee4c5-9b3f-4616-a2db-59288feef5e2">


<img width="636" alt="스크린샷 2024-07-08 오전 12 29 49" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/253a8b00-c1cc-4808-9839-22c324771b67">

저는 회원탈퇴한 사용자의 토큰을 스터디룸 수정 api 에 넣어보았는데 403 이 뜬 것을 확인할 수 있습니다.
리뷰하실 때에는 delete 처리되는 값이 전부 저랑 반대여야 성공입니다.