### PR TITLE
Feat : 전체 캐릭터 조회 API 개발

### DIFF
--- a/src/main/java/com/linkode/api_server/config/SecurityConfig.java
+++ b/src/main/java/com/linkode/api_server/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer<HttpSecurity>::disable)
                 .authorizeHttpRequests(requests ->
                         requests
-                                .requestMatchers("/login", "/oauth2/redirect","/user/avatar","/linkode").permitAll()  // 이 URL은 모두에게 허용
+                                .requestMatchers("/login", "/oauth2/redirect","/user/avatar","/linkode","/user/avatar/all").permitAll()  // 이 URL은 모두에게 허용
                                 .anyRequest().authenticated()  // 그 외의 모든 요청은 인증 필요
                 )
                 .sessionManagement(sessionManagement ->

--- a/src/main/java/com/linkode/api_server/controller/MemberController.java
+++ b/src/main/java/com/linkode/api_server/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.linkode.api_server.controller;
 import com.linkode.api_server.common.response.BaseResponse;
 import com.linkode.api_server.common.response.status.BaseExceptionResponseStatus;
 import com.linkode.api_server.dto.member.CreateAvatarRequest;
+import com.linkode.api_server.dto.member.GetAvatarAllResponse;
 import com.linkode.api_server.dto.member.GetAvatarResponse;
 import com.linkode.api_server.dto.member.UpdateAvatarRequest;
 import com.linkode.api_server.service.LoginService;
@@ -75,6 +76,15 @@ public class MemberController {
         String token = authorization.replace("Bearer ", "").trim();
         BaseExceptionResponseStatus responseStatus = loginService.logout(authorization);
         return new BaseResponse<>(responseStatus,null);
+    }
+
+    /**
+     * 전체 캐릭터 조회
+     */
+    @GetMapping("/avatar/all")
+    public BaseResponse<GetAvatarAllResponse> getAvatarAll(){
+        log.info("[MemberController.getAvatarAll]");
+        return new BaseResponse<>(memberService.getAvatarAll());
     }
 
 }

--- a/src/main/java/com/linkode/api_server/dto/member/GetAvatarAllResponse.java
+++ b/src/main/java/com/linkode/api_server/dto/member/GetAvatarAllResponse.java
@@ -1,0 +1,30 @@
+package com.linkode.api_server.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetAvatarAllResponse {
+    /**
+     * 캐릭터 전체 조회
+     */
+    private List<Avatar> avatar;
+    private List<Color> color;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Avatar{
+        private Long avatarId;
+        private String avatarImg;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Color{
+        private Long colorId;
+        private String hexCode;
+    }
+}

--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.Set;
 
 @Repository
-@Transactional(readOnly = true)
 public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom, Long> {
 
     @Query("SELECT ms.role FROM MemberStudyroom ms WHERE ms.studyroom.studyroomId = :studyroomId AND ms.member.memberId = :memberId")

--- a/src/main/java/com/linkode/api_server/repository/StudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/StudyroomRepository.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 @Repository
-@Transactional(readOnly = true)
 public interface StudyroomRepository extends JpaRepository<Studyroom, Long> {
     @Modifying
     @Query("UPDATE Studyroom sr SET sr.status = 'DELETE' WHERE sr.studyroomId = :studyroomId")

--- a/src/main/java/com/linkode/api_server/service/LoginService.java
+++ b/src/main/java/com/linkode/api_server/service/LoginService.java
@@ -12,6 +12,7 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -20,6 +21,7 @@ import java.util.Collections;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LoginService {
     @Value("${SOCIAL_CLIENT_ID}")
     private String clientId;

--- a/src/main/java/com/linkode/api_server/service/MemberService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberService.java
@@ -7,6 +7,7 @@ import com.linkode.api_server.domain.Color;
 import com.linkode.api_server.domain.Member;
 import com.linkode.api_server.domain.base.BaseStatus;
 import com.linkode.api_server.dto.member.CreateAvatarRequest;
+import com.linkode.api_server.dto.member.GetAvatarAllResponse;
 import com.linkode.api_server.dto.member.GetAvatarResponse;
 import com.linkode.api_server.dto.member.UpdateAvatarRequest;
 import com.linkode.api_server.repository.AvatarRepository;
@@ -17,11 +18,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -93,7 +98,6 @@ public class MemberService {
     /**
      * 캐릭터 조회
      */
-    @Transactional
     public GetAvatarResponse getAvatar(Long memberId){
         log.info("[MemberService.getAvatar]");
         Member member = memberRepository.findByMemberIdWithAvatarAndStatus(memberId, BaseStatus.ACTIVE)
@@ -103,6 +107,25 @@ public class MemberService {
         Long colorId = member.getColor().getColorId();
 
         return new GetAvatarResponse(nickname, avatarId, colorId);
+    }
+
+    /**
+     * 전체 캐릭터 조회
+     */
+    public GetAvatarAllResponse getAvatarAll(){
+        log.info("[MemberService.getAvatarAll]");
+
+        List<GetAvatarAllResponse.Avatar> avatars = avatarRepository.findAll().stream()
+                .filter(avatar -> avatar != null && avatar.getAvatarId() != null && avatar.getAvatarImg() != null)
+                .map(avatar -> new GetAvatarAllResponse.Avatar(avatar.getAvatarId(), avatar.getAvatarImg()))
+                .collect(Collectors.toList());
+
+        List<GetAvatarAllResponse.Color> colors = colorRepository.findAll().stream()
+                .filter(color -> color != null && color.getColorId() != null && color.getHexCode() != null)
+                .map(color -> new GetAvatarAllResponse.Color(color.getColorId(), color.getHexCode()))
+                .collect(Collectors.toList());
+
+        return new GetAvatarAllResponse(avatars, colors);
     }
 
 }

--- a/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
@@ -22,6 +22,7 @@ import static com.linkode.api_server.common.response.status.BaseExceptionRespons
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberStudyroomService {
 
     private final MemberstudyroomRepository memberstudyroomRepository;

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -26,6 +26,7 @@ import static com.linkode.api_server.common.response.status.BaseExceptionRespons
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StudyroomService {
 
     @Autowired


### PR DESCRIPTION
## 요약 (Summary)
<img width="280" alt="스크린샷 2024-07-10 오전 12 18 28" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/36fb90b5-6904-47ea-960a-a1df61f9dc94">

- [x] 위의 사진과 같은 전체 캐릭터 조회를 위한 API 구현하였습니다.
- [x] 명세서대로 구현하였습니다. [api 명세서](https://flashy-calculator-39f.notion.site/ba922b3fa4514f92aa44aea519cfe73d?pvs=4) 
- [x] 이 api 가 회원가입시에 한번, 캐릭터 수정 시에 한번 정도 사용될 것 같아서 헤더에 토큰이 없더라도 조회할 수 있도록 구현하였습니다.

## 🔑 변경 사항 (Key Changes)
- `GetAvatarAllResponse 작성` : Avatar 객체와 Color 객체를 리스트로 반환해줄 response dto 작성하였습니다. request 는 필요하지 않아서 작성하지 않았습니다.
- `SecurityConfig 수정` : 이 api 도 위에 요약에 작성되어있듯이 헤더에 토큰이 없더라도 접근가능해야할 것 같아서 인증을 요구하지 않는 api 로 구현하였습니다.
- `Repository 의 @Tranactional 어노테이션 삭제` : 레포지토리에 작성되어있던 트랜잭션 어노테이션을 지우고 서비스코드로 옮겨두었습니다.
- `MemberController.getAvatarAll, MemberService.getAvatarAll 작성 `: get 메소드라서 특이사항은 없습니다. 서비스코드에서 조회할 때에 avatar 한번, color 한번 총 두번 select 문으로 조회하도록 구현하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 명세서대로 반환이 되는지
- [x] 헤더에 토큰이 없어도 문제가 안되는지
- [x] 적절한 반환 방식인지 같이 고민해주기
- [x] 쿼리문의 갯수가 괜찮은지 확인해주기

## 확인 방법 
❗️application-local.yml 을 로컬 환경에 맞춰주세요
```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img2.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img3.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img4.png', 'ACTIVE');

INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드1', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드2', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드3', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드4', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드5', 'ACTIVE');
```

를 실행시켜주세요. 그 다음 다음의 api 요청을 아무런 헤더를 포함하지않고서 단독으로 요청보내주세요.
```
http://localhost:8080/user/avatar/all
```

<img width="401" alt="스크린샷 2024-07-10 오전 12 34 45" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/6ba0e67c-4d67-4f15-b7b3-287332b9d96a">

사진처럼 리스트로 반환되면 정상입니다!