### PR TITLE
Chore : 캐릭터생성 응답 수정

### DIFF
--- a/src/main/java/com/linkode/api_server/common/exception/AvatarException.java
+++ b/src/main/java/com/linkode/api_server/common/exception/AvatarException.java
@@ -1,0 +1,19 @@
+package com.linkode.api_server.common.exception;
+
+import com.linkode.api_server.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class AvatarException extends RuntimeException{
+    private final ResponseStatus exceptionStatus;
+
+    public AvatarException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public AvatarException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/linkode/api_server/common/exception_handler/AvatarExceptionControllerAdvice.java
+++ b/src/main/java/com/linkode/api_server/common/exception_handler/AvatarExceptionControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.linkode.api_server.common.exception_handler;
+
+import com.linkode.api_server.common.exception.AvatarException;
+import com.linkode.api_server.common.exception.ColorException;
+import com.linkode.api_server.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class AvatarExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(AvatarException.class)
+    public BaseErrorResponse handle_AvatarException(AvatarException e) {
+        log.error("[handle_AvatarException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/linkode/api_server/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/linkode/api_server/common/response/status/BaseExceptionResponseStatus.java
@@ -35,7 +35,12 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * color 관련 code : 7000대
      */
-    NOT_FOUND_COLOR(7000, HttpStatus.OK.value(), "컬러값을 찾을 수 없습니다.");
+    NOT_FOUND_COLOR(7000, HttpStatus.OK.value(), "컬러값을 찾을 수 없습니다."),
+
+    /**
+     * color 관련 code : 8000대
+     */
+    NOT_FOUND_AVATAR(8000, HttpStatus.OK.value(), "캐릭터를 찾을 수 없습니다.");
 
 
     private final int code;

--- a/src/main/java/com/linkode/api_server/controller/MemberController.java
+++ b/src/main/java/com/linkode/api_server/controller/MemberController.java
@@ -2,10 +2,7 @@ package com.linkode.api_server.controller;
 
 import com.linkode.api_server.common.response.BaseResponse;
 import com.linkode.api_server.common.response.status.BaseExceptionResponseStatus;
-import com.linkode.api_server.dto.member.CreateAvatarRequest;
-import com.linkode.api_server.dto.member.GetAvatarAllResponse;
-import com.linkode.api_server.dto.member.GetAvatarResponse;
-import com.linkode.api_server.dto.member.UpdateAvatarRequest;
+import com.linkode.api_server.dto.member.*;
 import com.linkode.api_server.service.LoginService;
 import com.linkode.api_server.service.MemberService;
 import com.linkode.api_server.util.JwtProvider;
@@ -33,10 +30,9 @@ public class MemberController {
      * 캐릭터 생성(회원가입)
      */
     @PostMapping("/avatar")
-    public BaseResponse<Void> createAvatar(@RequestBody CreateAvatarRequest createAvatarRequest) {
+    public BaseResponse<CreateAvatarResponse> createAvatar(@RequestBody CreateAvatarRequest createAvatarRequest) {
         log.info("[MemberController.createAvatar]");
-        memberService.createAvatar(createAvatarRequest);
-        return new BaseResponse<>(null);
+        return new BaseResponse<>(memberService.createAvatar(createAvatarRequest));
     }
 
     /**

--- a/src/main/java/com/linkode/api_server/dto/member/CreateAvatarResponse.java
+++ b/src/main/java/com/linkode/api_server/dto/member/CreateAvatarResponse.java
@@ -1,0 +1,14 @@
+package com.linkode.api_server.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateAvatarResponse {
+    /**
+     * 캐릭터 생성(회원가입)
+     */
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/linkode/api_server/repository/AvatarRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/AvatarRepository.java
@@ -1,10 +1,13 @@
 package com.linkode.api_server.repository;
 
 import com.linkode.api_server.domain.Avatar;
+import com.linkode.api_server.domain.base.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AvatarRepository extends JpaRepository<Avatar, Long> {
-
+    Optional<Avatar> findByAvatarIdAndStatus(Long avatarId, BaseStatus status);
 }

--- a/src/main/java/com/linkode/api_server/service/MemberService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberService.java
@@ -47,8 +47,8 @@ public class MemberService {
         } else {
             String nickname = createAvatarRequest.getNickname();
             Long avatarId = createAvatarRequest.getAvatarId();
-            Avatar avatar = avatarRepository.findById(avatarId)
-                    .orElseThrow(() -> new IllegalArgumentException("Invalid avatarId: " + avatarId));
+            Avatar avatar = avatarRepository.findByAvatarIdAndStatus(avatarId, BaseStatus.ACTIVE)
+                    .orElseThrow(() -> new MemberException(NOT_FOUND_AVATAR));
             Long colorId = createAvatarRequest.getColorId();
             Color color = colorRepository.findByColorIdAndStatus(colorId, BaseStatus.ACTIVE)
                     .orElseThrow(()-> new ColorException(NOT_FOUND_COLOR));

--- a/src/main/java/com/linkode/api_server/service/MemberService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberService.java
@@ -6,13 +6,11 @@ import com.linkode.api_server.domain.Avatar;
 import com.linkode.api_server.domain.Color;
 import com.linkode.api_server.domain.Member;
 import com.linkode.api_server.domain.base.BaseStatus;
-import com.linkode.api_server.dto.member.CreateAvatarRequest;
-import com.linkode.api_server.dto.member.GetAvatarAllResponse;
-import com.linkode.api_server.dto.member.GetAvatarResponse;
-import com.linkode.api_server.dto.member.UpdateAvatarRequest;
+import com.linkode.api_server.dto.member.*;
 import com.linkode.api_server.repository.AvatarRepository;
 import com.linkode.api_server.repository.ColorRepository;
 import com.linkode.api_server.repository.MemberRepository;
+import com.linkode.api_server.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,12 +32,14 @@ public class MemberService {
     private final MemberStudyroomService memberStudyroomService;
     private final ColorRepository colorRepository;
     private final TokenService tokenService;
+    private final JwtProvider jwtProvider;
+
 
     /**
      * 캐릭터 생성(회원가입)
      */
     @Transactional
-    public void createAvatar(CreateAvatarRequest createAvatarRequest) {
+    public CreateAvatarResponse createAvatar(CreateAvatarRequest createAvatarRequest) {
         log.info("[MemberService.createAvatar]");
         String githubId = createAvatarRequest.getGithubId();
         if (memberRepository.existsByGithubIdAndStatus(githubId, BaseStatus.ACTIVE)) {
@@ -55,6 +55,12 @@ public class MemberService {
 
             Member member = new Member(githubId, nickname, avatar, color, BaseStatus.ACTIVE);
             memberRepository.save(member);
+
+            String jwtAccessToken = jwtProvider.createAccessToken(githubId);
+            String jwtRefreshToken = jwtProvider.createRefreshToken(githubId);
+            // 레디스 저장
+            tokenService.storeToken(jwtRefreshToken, githubId);
+            return new CreateAvatarResponse(jwtAccessToken,jwtRefreshToken);
         }
     }
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 기존의 캐릭터 생성(회원가입)에서 json 응답에 토큰 누락된 부분 수정하였습니다. [수정된 회원가입 명세서 확인](https://flashy-calculator-39f.notion.site/fa9cc7204b51464091be618920faa244?pvs=4)

## 🔑 변경 사항 (Key Changes)
- `CreateAvatarResponse dto 작성` : 원래는 void 로 반환하였는데 dto 작성해서 명세서대로 토큰 2개 반환하도록 하였습니다
- `MemberController.createAvatar , MemberService.createAvatar 수정` : 각각 void 를 반환하던 것을 CreateAvatarResponse 를 반환하도록 수정하였고 서비스에서는 깃허브 아이디로 토큰 생성해서 반환하는 로직은 로그인과 동일하게 구성하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 명세서대로 토큰이 반환되는지
- [x] 동일한 깃허브 아이디에 대한 요청을 두번 했을 때에 이미 있는 회원이라는 예외처리가 되는지
- [x] 데이터베이스에 데이터가 제대로 저장되는지
- [x] 명세서에서 올바른 값을 반환하는지(누락된 값은 없는지 고민해주기!!!!)

## 확인 방법 
❗️application-local.yml 을 로컬 환경에 맞춰 수정해주세요
```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img2.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img3.png', 'ACTIVE');
INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img4.png', 'ACTIVE');

INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드1', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드2', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드3', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드4', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드5', 'ACTIVE');
```

워크벤치에서 위의 쿼리문을 먼저 실행시켜주세요.
레디스에 키값을 전부 삭제한 상태로 시작해주세요.

✅Post 요청 보내주세요 (헤더에 토큰값은 필요하지않습니당)
```
http://localhost:8080/user/avatar
```

<img width="300" alt="스크린샷 2024-07-10 오후 2 38 29" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/e4ffccd1-796b-43e2-96aa-224d5114f7c0">

최초 요청시 다음과 같이 뜨는게 정상입니다.

<img width="600" alt="스크린샷 2024-07-10 오후 2 39 08" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/51f00ff9-2286-40d7-9648-10f9c15ab857">

워크벤치에는 다음과 같이 저장됩니다.

<img width="300" alt="스크린샷 2024-07-10 오후 2 39 39" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/d02b19c3-250b-4962-a0df-78abb882bf34">

동일한 회원에 대해서 요청을 보내면 이미 있는 회원이라고 뜹니다.

<img width="300" alt="스크린샷 2024-07-10 오후 2 56 59" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/3d7d183d-579e-4b34-bcf2-5c1b99e7f0ef">

<img width="300" alt="스크린샷 2024-07-10 오후 2 57 16" src="https://github.com/Linkode2024/Linkode2024_BE/assets/122519994/bb8a742b-8399-485f-b933-d3e45781ee6c">

아바타 id 와 컬러 id 에 대한 예외처리도 되어있습니다