### PR TITLE
Feat : 스터디룸조회

### DIFF
--- a/src/main/java/com/linkode/api_server/controller/StudyroomController.java
+++ b/src/main/java/com/linkode/api_server/controller/StudyroomController.java
@@ -92,4 +92,13 @@ public class StudyroomController {
         return new BaseResponse<>(studyroomService.createStudyroomCode(memberId,studyroomId));
     }
 
+    /**
+     * 스터디룸 리스트 조회
+     */
+    @GetMapping("")
+    public BaseResponse<MemberStudyroomListResponse> getStudyroomList(@RequestHeader("Authorization") String authorization){
+        log.info("[StudyroomController.getStudyroomList]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(memberStudyroomService.getStudyroomList(memberId));
+    }
 }

--- a/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
@@ -142,4 +142,13 @@ public class MemberStudyroomService {
         return new MemberStudyroomListResponse(studyroomList);
     }
 
+
+    /**
+     * 스터디룸 리스트 조회
+     */
+    public MemberStudyroomListResponse getStudyroomList(Long memberId){
+        log.info("[StudyroomService.getStudyroomList]");
+        MemberStudyroomListResponse latestStudyroomList = getMemberStudyroomList(memberId);
+        return latestStudyroomList;
+    }
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 좌측바에 뜨는 스터디룸 조회를 구현하였습니다.
- [x] 이전 스터디룸 탈퇴에서 사용하였던 dto 와 메소드 모두 재활용하였습니다.

## 🔑 변경 사항 (Key Changes)
- StudyroomController.getStudyroomList 와 MemberStudyroomService.getStudyroomList 작성 하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [ ] 명세서대로 반환되는지

## 확인 방법 
```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');

INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드1', 'ACTIVE');

INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color_id,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'jsilver01','두바이2', 1, 'ACTIVE');
INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color_id,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'Mouon','두바이', 1, 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom2', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 'New Studyroom3', 'Profile for New Studyroom', 'ACTIVE');


INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 1, 'CAPTAIN', 'ACTIVE');
```

쿼리문을 실행시켜주세요. 필요하다면 member_studyroom 을 더 생성하셔도 됩니다.

```
http://localhost:8080/studyroom
```

헤더에 토큰 넣고 get 요청 보내면 
<img width="549" alt="스크린샷 2024-07-16 오전 12 44 41" src="https://github.com/user-attachments/assets/efba5612-7661-4959-8cf8-65958ab0018f">

다음과 같이 옵니다. 만약 스터디룸에 하나도 속해있지 않는다면 
<img width="549" alt="스크린샷 2024-07-16 오전 12 45 52" src="https://github.com/user-attachments/assets/f1d862b5-ae99-4f9d-bb86-dae11cfce8e8">

비어있도록 구현하였습니다.