### PR TITLE
Fix : 스터디룸수정 api 사진 업로드 수정

### DIFF
--- a/src/main/java/com/linkode/api_server/controller/LoginController.java
+++ b/src/main/java/com/linkode/api_server/controller/LoginController.java
@@ -26,10 +26,4 @@ public class LoginController {
         return new BaseResponse<>(loginService.githubLogin(code));
     }
 
-    @GetMapping("/test")
-    public String test(@RequestHeader("authorization") String authorization){
-
-        return "success!";
-    }
-
 }

--- a/src/main/java/com/linkode/api_server/controller/StudyroomController.java
+++ b/src/main/java/com/linkode/api_server/controller/StudyroomController.java
@@ -11,10 +11,8 @@ import com.linkode.api_server.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.*;
 

--- a/src/main/java/com/linkode/api_server/controller/StudyroomController.java
+++ b/src/main/java/com/linkode/api_server/controller/StudyroomController.java
@@ -69,11 +69,10 @@ public class StudyroomController {
      * 스터디룸 수정
      */
     @PatchMapping("")
-    public BaseResponse<Void> modifyStudyroom(@RequestHeader("Authorization") String authorization, @RequestBody PatchStudyroomRequest patchStudyroomRequest) {
+    public BaseResponse<CreateStudyroomResponse> modifyStudyroom(@RequestHeader("Authorization") String authorization, @ModelAttribute PatchStudyroomRequest patchStudyroomRequest) {
         log.info("[StudyroomController.modifyStudyroom]");
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
-        studyroomService.modifyStudyroom(memberId, patchStudyroomRequest);
-        return new BaseResponse<>(null);
+        return new BaseResponse<>(studyroomService.modifyStudyroom(memberId, patchStudyroomRequest));
     }
 
     /**

--- a/src/main/java/com/linkode/api_server/dto/studyroom/CreateStudyroomResponse.java
+++ b/src/main/java/com/linkode/api_server/dto/studyroom/CreateStudyroomResponse.java
@@ -1,18 +1,19 @@
 package com.linkode.api_server.dto.studyroom;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
-@Getter @Setter
-@AllArgsConstructor
+@Getter
 @NoArgsConstructor
 public class CreateStudyroomResponse {
 
     private long studyroomId;
     private String studyroomName;
-
     private String studyroomProfile;
 
+    @Builder
+    public CreateStudyroomResponse(long studyroomId, String studyroomName, String studyroomProfile) {
+        this.studyroomId = studyroomId;
+        this.studyroomName = studyroomName;
+        this.studyroomProfile = studyroomProfile;
+    }
 }

--- a/src/main/java/com/linkode/api_server/dto/studyroom/PatchStudyroomRequest.java
+++ b/src/main/java/com/linkode/api_server/dto/studyroom/PatchStudyroomRequest.java
@@ -1,9 +1,11 @@
 package com.linkode.api_server.dto.studyroom;
 
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -14,6 +16,8 @@ public class PatchStudyroomRequest {
      * 스터디룸 수정
      */
     private Long studyroomId;
+    @Nullable
     private String studyroomName;
-    private String studyroomImg;
+    @Nullable
+    private MultipartFile studyroomImg;
 }

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -146,13 +146,14 @@ public class StudyroomService {
      * 스터디룸 수정
      */
     @Transactional
-    public void modifyStudyroom(Long memberId, PatchStudyroomRequest patchStudyroomRequest){
+    public CreateStudyroomResponse modifyStudyroom(Long memberId, PatchStudyroomRequest patchStudyroomRequest){
         log.info("[StudyroomService.modifyStudyroom]");
         Long studyroomId = patchStudyroomRequest.getStudyroomId();
         MemberStudyroom memberStudyroom = memberstudyroomRepository.findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(memberId, studyroomId,BaseStatus.ACTIVE)
-                .orElseThrow(()->new StudyroomException(NOT_FOUND_MEMBERROLE));
+                .orElseThrow(()->new StudyroomException(NOT_FOUND_MEMBER_STUDYROOM));
 
         if(memberStudyroom.getRole().equals(MemberRole.CAPTAIN)){
+            log.info("[StudyroomService.modifyStudyroom -- MEMBERROLE : CAPTAIN]");
             Studyroom studyroom = studyroomRepository.findById(studyroomId)
                     .orElseThrow(()-> new StudyroomException(NOT_FOUND_STUDYROOM));
 
@@ -169,6 +170,7 @@ public class StudyroomService {
 
             studyroom.updateStudyroomInfo(studyroomName,studyroomImg);
             studyroomRepository.save(studyroom);
+            return new CreateStudyroomResponse(studyroomId,studyroomName,studyroomImg);
         }else{
             throw new StudyroomException(INVALID_ROLE);
         }

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -17,8 +17,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import com.linkode.api_server.domain.Member;
 import com.linkode.api_server.domain.Studyroom;
@@ -153,17 +151,22 @@ public class StudyroomService {
         Long studyroomId = patchStudyroomRequest.getStudyroomId();
         MemberStudyroom memberStudyroom = memberstudyroomRepository.findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(memberId, studyroomId,BaseStatus.ACTIVE)
                 .orElseThrow(()->new StudyroomException(NOT_FOUND_MEMBERROLE));
+
         if(memberStudyroom.getRole().equals(MemberRole.CAPTAIN)){
             Studyroom studyroom = studyroomRepository.findById(studyroomId)
                     .orElseThrow(()-> new StudyroomException(NOT_FOUND_STUDYROOM));
+
             String studyroomName = studyroom.getStudyroomName();
             String studyroomImg = studyroom.getStudyroomProfile();
+
             if(patchStudyroomRequest.getStudyroomName() != null){
                 studyroomName = patchStudyroomRequest.getStudyroomName();
             }
+
             if(patchStudyroomRequest.getStudyroomImg() != null){
-                studyroomImg = patchStudyroomRequest.getStudyroomImg();
+                studyroomImg = getProfileUrl(patchStudyroomRequest.getStudyroomImg());
             }
+
             studyroom.updateStudyroomInfo(studyroomName,studyroomImg);
             studyroomRepository.save(studyroom);
         }else{

--- a/src/main/java/com/linkode/api_server/service/StudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/StudyroomService.java
@@ -170,7 +170,11 @@ public class StudyroomService {
 
             studyroom.updateStudyroomInfo(studyroomName,studyroomImg);
             studyroomRepository.save(studyroom);
-            return new CreateStudyroomResponse(studyroomId,studyroomName,studyroomImg);
+            return CreateStudyroomResponse.builder()
+                    .studyroomId(studyroomId)
+                    .studyroomName(studyroomName)
+                    .studyroomProfile(studyroomImg)
+                    .build();
         }else{
             throw new StudyroomException(INVALID_ROLE);
         }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 스터디룸 수정 api 의 사진 업로드 부분이 실제 파일을 받을 수 있는 것이 아니라 단순 String 값을 받아 저장하도록 구현되어 있어서 getProfileUrl 메소드를 활용하여 S3 에 파일을 올릴 수 있도록 수정하였습니다. 
- [x] 이외의 다른 수정사항은 없습니다.

## 🔑 변경 사항 (Key Changes)
- `PatchStudyroomRequest 수정` : String 으로 받던 StudyroomImg 를 MultipartFile 로 수정하였으며, Patch 메소드이므로 StudyroomName 과 StudyroomImg 모두 @Nullable 어노테이션을 붙여주었습니다. 
- `StudyroomService.modifyStudyroom 수정` : 해당 메소드에서 원래는 String 을 request 로 받아 저장하였는데, 이 부분은 현준님이 만들어두신 getProfileUrl 메소드를 활용하여 S3 에 파일을 올릴 수 있도록 수정하였습니다. 👍

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 명세서 대로 반환되는지
- [x] 명세서가 정확하게 수정되었는지 [명세서확인하기](https://flashy-calculator-39f.notion.site/693fb23fa7d94f94a35203a941f05456?pvs=4)
- [x] 수정된 사진이 S3 에 업로드 되는지 (궁금한게 그러면 이전 파일은 그대로 유지가 되나요 아니면 삭제가 되나요??? 삭제가 안된다면 그냥 계속 사진들이 쌓이나요??)
- [x] 이름이나 사진이 비어있어도 요청이 정상적으로 가며, 정상적으로 수정되는지
- [x] 반환해주는게 전부 동일해서 지금은 CreateStudyroomResponse 를 가져다가 썼는데, 이 dto 의 이름을 바꿔서 같이 써야할지, 아니면 새롭게 파일을 하나 생성해야할지

## 확인 방법 
❗️application-local.yml 이 로컬 상황에 맞는지 확인하기(아마 현준님 로컬에 맞을걸요?)

```
use linkode;

INSERT INTO avatar (created_at, modified_at, avatar_img, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'img1.png', 'ACTIVE');
INSERT INTO color (created_at, modified_at, hex_code, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '헥스코드1', 'ACTIVE');

INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'jsilver01','룽삥뿡',1, 'ACTIVE');
INSERT INTO member (created_at, modified_at, avatar_id, github_id, nickname, color,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 1, 'Mouon', '우짤짜증나!',1, 'ACTIVE');

INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', '정은이 스터디룸', 'Profile for New Studyroom', 'ACTIVE');
INSERT INTO studyroom (created_at, modified_at, studyroom_name, studyroom_profile, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', '똥멍충이 스터디룸', 'Profile for New Studyroom', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 1, 'CAPTAIN', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 1, 2, 'CREW', 'ACTIVE');

INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 1, 'CREW', 'ACTIVE');
INSERT INTO member_studyroom (created_at, modified_at, member_id, studyroom_id, role, status) VALUES
('2024-07-04 12:00:00.000000', '2024-07-04 12:00:00.000000', 2, 2, 'CAPTAIN', 'ACTIVE');
```
쿼리문을 돌리고 소셜로그인을 한 후 토큰받아 헤더에 넣어주세요.

그다음 아래의 주소로 PATCH 요청 보내주세요. 폼데이터 형식을 사용합니다.
```
http://localhost:8080/studyroom
```
유저별로 CAPTAIN 한번 CREW 한번이기 때문에 별도로 유저의 순서를 변경할 필요는 없습니다. 저와 반대로 결과가 나오면 성공입니다.

<img width="808" alt="스크린샷 2024-08-14 오후 3 28 02" src="https://github.com/user-attachments/assets/6216f757-77ed-489f-9fb9-9fcd69d56f3d">

<img width="695" alt="스크린샷 2024-08-14 오후 3 29 22" src="https://github.com/user-attachments/assets/5530ae95-88b9-4295-ae1d-c72dfc674117">

<img width="695" alt="스크린샷 2024-08-14 오후 3 29 42" src="https://github.com/user-attachments/assets/711902fb-0419-49b9-9ced-0edfaf667959">

하나 궁금한 점은 테스트를 해보니까 지금은 동일한 사진이어도 요청을 보내는 만큼 S3 에 계속해서 새롭게 올라가는것 같은데 혹시 이 부분은 원래 이렇게 쓰나 궁금합니다!