### PR TITLE
Refactor : 맴버 스터디룸 조회,탈퇴 리펙토링

### DIFF
--- a/src/main/java/com/linkode/api_server/controller/StudyroomController.java
+++ b/src/main/java/com/linkode/api_server/controller/StudyroomController.java
@@ -43,10 +43,10 @@ public class StudyroomController {
     public BaseResponse<MemberStudyroomListResponse> leaveStudyroom(@RequestHeader("Authorization") String authorization, @RequestParam long studyroomId){
         log.info("[StudyroomController.leaveStudyroom]");
         long memberId = jwtProvider.extractIdFromHeader(authorization);
-        BaseExceptionResponseStatus responseStatus = memberStudyroomService.leaveStudyroom(studyroomId, memberId);
+        memberStudyroomService.leaveStudyroom(studyroomId, memberId);
         MemberStudyroomListResponse latestStudyroomList = memberStudyroomService.getMemberStudyroomList(memberId);
         log.info("Run leaveStudyroom API ");
-        return new BaseResponse<>(responseStatus, latestStudyroomList);
+        return new BaseResponse<>(SUCCESS, latestStudyroomList);
     }
 
     @PostMapping("/generation")

--- a/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
+++ b/src/main/java/com/linkode/api_server/repository/MemberstudyroomRepository.java
@@ -36,15 +36,16 @@ public interface MemberstudyroomRepository extends JpaRepository<MemberStudyroom
     @Query("UPDATE MemberStudyroom ms SET ms.status = :status WHERE ms IN :memberStudyrooms")
     void updateMemberStudyroomStatus(@Param("memberStudyrooms") List<MemberStudyroom> memberStudyrooms, @Param("status") BaseStatus status);
 
-    @Query("SELECT ms.role, s.studyroomName, s.studyroomProfile, m.memberId, m.nickname, m.avatar.id, m.color.id " +
+    @Query("SELECT ms " +
             "FROM MemberStudyroom ms " +
-            "JOIN ms.studyroom s " +
-            "JOIN s.memberStudyroomList msl " +
-            "JOIN msl.member m " +
-            "WHERE ms.studyroom.studyroomId = :studyroomId " +
-            "AND ms.member.memberId = :memberId " +
+            "JOIN FETCH ms.studyroom s " +
+            "JOIN FETCH ms.member m " +
+            "JOIN FETCH s.memberStudyroomList msl " +
+            "JOIN FETCH msl.member " +
+            "WHERE s.studyroomId = :studyroomId " +
+            "AND m.memberId = :memberId " +
             "AND ms.status = :status")
-    List<Object[]> getStudyroomDetail(long studyroomId,long memberId, BaseStatus status);
+    Optional<MemberStudyroom> getStudyroomDetail(long studyroomId,long memberId, BaseStatus status);
 
 
     /**

--- a/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
@@ -108,29 +108,13 @@ public class MemberStudyroomService {
      *
      * */
     @Transactional
-    public BaseExceptionResponseStatus leaveStudyroom(long studyroomId, long memberId){
+    public void leaveStudyroom(long studyroomId, long memberId){
         log.info("[MemberStudyroomService.leaveStudyroom]");
-        try {
             MemberStudyroom memberStudyroom = memberstudyroomRepository
                     .findByMember_MemberIdAndStudyroom_StudyroomIdAndStatus(memberId,studyroomId,BaseStatus.ACTIVE)
                     .orElseThrow(()-> new MemberStudyroomException(NOT_FOUND_MEMBER_STUDYROOM));
-            if(memberStudyroom.getRole()==MemberRole.CAPTAIN) throw new
-                    LeaveStudyroomExeption(CANNOT_LEAVE_STUDYROOM);
+            if(memberStudyroom.getRole()==MemberRole.CAPTAIN) throw new MemberStudyroomException(CANNOT_LEAVE_STUDYROOM);
             memberStudyroom.updateMemberStudyroomStatus(BaseStatus.DELETE);
-            memberstudyroomRepository.save(memberStudyroom);
-            return BaseExceptionResponseStatus.SUCCESS;
-        }
-        catch (LeaveStudyroomExeption e) {
-            log.error("MemberStudyroomException! -> ", e);
-            return CANNOT_LEAVE_STUDYROOM;
-        }
-        catch (MemberStudyroomException e) {
-            log.error("MemberStudyroomException! -> ", e);
-            return NOT_FOUND_MEMBER_STUDYROOM;
-        }
-        catch (Exception e){
-            return FAILURE;
-        }
     }
 
     /**

--- a/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberStudyroomService.java
@@ -71,23 +71,19 @@ public class MemberStudyroomService {
      * */
     public DetailStudyroomResponse getStudyroomDetail(long studyroomId, long memberId) {
         log.info("[MemberStudyroomService.getStudyroomDetail]");
-        List<Object[]> results = memberstudyroomRepository.getStudyroomDetail(studyroomId, memberId, BaseStatus.ACTIVE);
+        MemberStudyroom memberStudyroom = memberstudyroomRepository.getStudyroomDetail(studyroomId,memberId,BaseStatus.ACTIVE)
+                .orElseThrow(()-> new MemberStudyroomException(NOT_FOUND_MEMBER_STUDYROOM));
 
-        if (results.isEmpty()) {
-            throw new MemberStudyroomException(NOT_FOUND_MEMBER_STUDYROOM);
-        }
-        Object[] firstRow = results.get(0);
-        MemberRole role = (MemberRole) firstRow[0];
-        String studyroomName = (String) firstRow[1];
-        String studyroomProfile = (String) firstRow[2];
+        MemberRole role = memberStudyroom.getRole();
+        String studyroomName = memberStudyroom.getStudyroom().getStudyroomName();
+        String studyroomProfile = memberStudyroom.getStudyroom().getStudyroomProfile();
 
-
-        List<DetailStudyroomResponse.Member> members = results.stream()
-                .map(row -> DetailStudyroomResponse.Member.builder()
-                        .memberId((Long) row[3])
-                        .nickname((String) row[4])
-                        .avatarId((Long) row[5])
-                        .colorId((Long) row[6])
+        List<DetailStudyroomResponse.Member> members = memberStudyroom.getStudyroom().getMemberStudyroomList().stream()
+                .map(member -> DetailStudyroomResponse.Member.builder()
+                        .memberId(member.getMember().getMemberId())
+                        .nickname(member.getMember().getNickname())
+                        .avatarId(member.getMember().getAvatar().getAvatarId())
+                        .colorId(member.getMember().getColor().getColorId())
                         .build())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 스터디룸 탈퇴 더티체킹 활용하도록 save메서드를 지우고, 일부 로직을 정리했습니다.
- [x] 스터디룸 상세 조회시  select해와서 row단위로 값을 가져오던 것을 수정하였습니다!

## 🔑 변경 사항 (Key Changes)

- MemberStudyroomService : 
         - leaveStudyroom : 더티체킹 활용하도록 save메서드를 지우고, 일부 로직을 정리했습니다.
         - getStudyroomDetail : 이전에는 필요한 것만 select 했었는데, 확장에도 닫혀있고, 쓰려면 레포지토리 코드를 봐야한다는 점에서 비효율적이라고 판단하여 패치조인으로 수정했습니다.
-MemberstudyroomRepository : getStudyroomDetail 을 패치조인으로 수정하였습니다! 


## 📝 리뷰 요구사항 (To Reviewers)

- [x] 모든 수정사항의 기능은 동일합니다. 수정이 목적에 맞게 잘 이루어졌는지만 확인해주셔도 무방할 것 같습니다!


