### PR TITLE
Refactor : 소셜로그인응답수정

### DIFF
--- a/src/main/java/com/linkode/api_server/controller/LoginController.java
+++ b/src/main/java/com/linkode/api_server/controller/LoginController.java
@@ -6,7 +6,6 @@ import com.linkode.api_server.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/linkode/api_server/domain/Member.java
+++ b/src/main/java/com/linkode/api_server/domain/Member.java
@@ -35,7 +35,6 @@ public class Member extends BaseTime {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private BaseStatus status;
 
-
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<MemberStudyroom> memberStudyroomList = new ArrayList<>();

--- a/src/main/java/com/linkode/api_server/dto/member/LoginResponse.java
+++ b/src/main/java/com/linkode/api_server/dto/member/LoginResponse.java
@@ -1,16 +1,19 @@
 package com.linkode.api_server.dto.member;
 
+import com.linkode.api_server.domain.Member;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class LoginResponse {
     /**
      * 깃허브 소셜로그인
      */
-    private boolean memberStatus;
+    private Long memberId;
     private String githubId;
     private String accessToken;
     private String refreshToken;
@@ -18,17 +21,38 @@ public class LoginResponse {
     private List<Studyroom> studyroomList;
 
     @Getter
-    @AllArgsConstructor
-    public static class Profile{
+    @Builder
+    public static class Profile {
         private String nickname;
         private Long avatarId;
         private Long colorId;
+
+        // 정적 팩토리 메서드
+        public static Profile from(Member member) {
+            return Profile.builder()
+                    .nickname(member.getNickname())
+                    .avatarId(member.getAvatar().getAvatarId())
+                    .colorId(member.getColor().getColorId())
+                    .build();
+        }
     }
 
     @Getter
     @AllArgsConstructor
-    public static class Studyroom{
+    public static class Studyroom {
         private Long studyroomId;
         private String studyroomProfile;
+    }
+
+    // 정적 팩토리 메서드
+    public static LoginResponse of(Member member, String accessToken, String refreshToken, List<Studyroom> studyroomList) {
+        return LoginResponse.builder()
+                .memberId(member.getMemberId())
+                .githubId(member.getGithubId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .profile(Profile.from(member))
+                .studyroomList(studyroomList)
+                .build();
     }
 }

--- a/src/main/java/com/linkode/api_server/service/LoginService.java
+++ b/src/main/java/com/linkode/api_server/service/LoginService.java
@@ -5,7 +5,6 @@ import com.linkode.api_server.common.exception.MemberStudyroomException;
 import com.linkode.api_server.common.response.status.BaseExceptionResponseStatus;
 import com.linkode.api_server.domain.Member;
 import com.linkode.api_server.repository.MemberstudyroomRepository;
-import com.linkode.api_server.repository.StudyroomRepository;
 import com.linkode.api_server.util.JwtProvider;
 import com.linkode.api_server.domain.base.BaseStatus;
 import com.linkode.api_server.dto.member.LoginResponse;
@@ -22,7 +21,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_MEMBER;
@@ -48,33 +46,38 @@ public class LoginService {
      */
     public LoginResponse githubLogin(String code){
         log.info("[LoginService.githubLogin]");
-        String accessToken = getAccessToken(code);
-        String githubId = getUserInfo(accessToken);
-        boolean memberStatus = false;
-        Optional<Member> member = memberRepository.findByGithubIdAndStatus(githubId, BaseStatus.ACTIVE);
-        log.info("[깃허브 아이디로 member 찾기]");
+        String githubId = getUserInfo(getAccessToken(code)); //깃허브 서버와 통신해서 유저 정보 받아오기
+        Member member = null;
         String jwtAccessToken = null;
         String jwtRefreshToken = null;
-        LoginResponse.Profile profile = null;
         List<LoginResponse.Studyroom> studyroom = null;
-        if(member.isPresent()){
-            Member member1 = member.get();
-            memberStatus = true;
-            jwtAccessToken = jwtProvider.createAccessToken(githubId);
+
+        member = memberRepository.findByGithubIdAndStatus(githubId, BaseStatus.ACTIVE)
+                .orElseThrow(()-> new MemberException(NOT_FOUND_MEMBER));
+        log.info("[깃허브 아이디로 member 찾기]");
+
+        if(member!=null){
+            jwtAccessToken = jwtProvider.createAccessToken(member);
             log.info("[엑세스토큰 발급~]");
-            jwtRefreshToken = jwtProvider.createRefreshToken(githubId);
+            jwtRefreshToken = jwtProvider.createRefreshToken(member);
             log.info("[리프레시토큰 발급~]");
-            // 레디스 저장가
+            // 레디스 저장
             tokenService.storeToken(jwtRefreshToken, githubId);
-            profile = new LoginResponse.Profile(member1.getNickname(), member1.getAvatar().getAvatarId(), member1.getColor().getColorId());
-            studyroom = memberstudyroomRepository.findByMemberIdAndStatus(member1.getMemberId(), BaseStatus.ACTIVE)
+            LoginResponse.Profile.from(member);
+            studyroom = memberstudyroomRepository.findByMemberIdAndStatus(member.getMemberId(), BaseStatus.ACTIVE)
                     .orElseThrow(()->new MemberStudyroomException(NOT_FOUND_MEMBER_STUDYROOM))
                     .stream()
                     .map(ms -> new LoginResponse.Studyroom(ms.getStudyroom().getStudyroomId(), ms.getStudyroom().getStudyroomProfile()))
                     .collect(Collectors.toList());
             log.info("[studyroom stream 으로 찾아서 반환하기]");
         }
-        return new LoginResponse(memberStatus,githubId,jwtAccessToken,jwtRefreshToken, profile, studyroom);
+        // Member가 없을 경우 Profile 및 Studyroom은 null 또는 빈 값 처리
+        return LoginResponse.of(
+                member,
+                jwtAccessToken,
+                jwtRefreshToken,
+                studyroom
+        );
     }
 
     /**

--- a/src/main/java/com/linkode/api_server/service/MemberService.java
+++ b/src/main/java/com/linkode/api_server/service/MemberService.java
@@ -56,8 +56,8 @@ public class MemberService {
             Member member = new Member(githubId, nickname, avatar, color, BaseStatus.ACTIVE);
             memberRepository.save(member);
 
-            String jwtAccessToken = jwtProvider.createAccessToken(githubId);
-            String jwtRefreshToken = jwtProvider.createRefreshToken(githubId);
+            String jwtAccessToken = jwtProvider.createAccessToken(member);
+            String jwtRefreshToken = jwtProvider.createRefreshToken(member);
             // 레디스 저장
             tokenService.storeToken(jwtRefreshToken, githubId);
             return new CreateAvatarResponse(jwtAccessToken,jwtRefreshToken);

--- a/src/main/java/com/linkode/api_server/util/JwtProvider.java
+++ b/src/main/java/com/linkode/api_server/util/JwtProvider.java
@@ -1,14 +1,10 @@
 package com.linkode.api_server.util;
 
 import com.linkode.api_server.domain.Member;
-import com.linkode.api_server.domain.base.BaseStatus;
-import com.linkode.api_server.repository.MemberRepository;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -16,7 +12,6 @@ import java.util.NoSuchElementException;
 
 @Component
 public class JwtProvider {
-    private final MemberRepository memberRepository;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -27,15 +22,9 @@ public class JwtProvider {
     @Value("${jwt.refresh-token-expiration}")
     private long refreshTokenExpiration;
 
-    public JwtProvider(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
-
     // Access Token 생성
-    public String createAccessToken(String githubId) {
-        Member member = memberRepository.findByGithubIdAndStatus(githubId, BaseStatus.ACTIVE)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 깃허브 아이디로 유저를 찾을 수 없습니다.: " + githubId));
-        Claims claims = Jwts.claims().setSubject(githubId);
+    public String createAccessToken(Member member) {
+        Claims claims = Jwts.claims().setSubject(member.getGithubId());
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenExpiration);
 
@@ -49,10 +38,8 @@ public class JwtProvider {
     }
 
     // Refresh Token 생성
-    public String createRefreshToken(String githubId) {
-        Member member = memberRepository.findByGithubIdAndStatus(githubId, BaseStatus.ACTIVE)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 깃허브 아이디로 유저를 찾을 수 없습니다.: " + githubId));
-        Claims claims = Jwts.claims().setSubject(githubId);
+    public String createRefreshToken(Member member) {
+        Claims claims = Jwts.claims().setSubject(member.getGithubId());
         Date now = new Date();
         Date validity = new Date(now.getTime() + refreshTokenExpiration);
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 소셜로그인에서 memberId 를 추가로 반환하는 작업 수행하였습니다.
- [x] 그 과정에서 빌더와 정적팩토리 메소드를 도입하려고 하다보니 MemberStatus 에 대한 문제가 생기기도 하고, 굳이 필요없다고 판단해서 회원이 데이터베이스에 없는 경우에는 MemberException 으로 예외를 터트리고 문제가 없는 경우는 명세서와 동일한 json 을 반환하도록 수정하였습니다! [변경된 명세서 확인~!](https://quixotic-casquette-1d9.notion.site/d73ba03ea5dd4f3cb40cdc1219e2ffdd?pvs=4)

## 🔑 변경 사항 (Key Changes)

- LoginResponse 에 빌더패턴과 정적팩토리메소드를 적용하였습니다
- 또한, LoginService 에서 기존에 사용하던 memberStatus 를 제거하였습니다.
- 기존에 엑세스토큰과 리프레시 토큰 발급에서 사용되던 2개의 select 문을 파라미터로 githubId 를 받는 것에서 member 객체를 반환하는 것으로 수정하여 불필요한 데이터베이스 커넥션을 줄였습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 명세서대로 반환되는지~~
- [x] 엑세스/리프레시 토큰이 생성될 시에 쿼리문이 안날라가는지
