### PR TITLE
Fix: Member 객체 없을 시 컨트롤러에서 메세지로 반환하도록 수정

### DIFF
--- a/src/main/java/com/linkode/api_server/controller/LoginController.java
+++ b/src/main/java/com/linkode/api_server/controller/LoginController.java
@@ -1,5 +1,6 @@
 package com.linkode.api_server.controller;
 
+import com.linkode.api_server.common.exception.MemberException;
 import com.linkode.api_server.common.response.BaseResponse;
 import com.linkode.api_server.dto.member.LoginResponse;
 import com.linkode.api_server.service.LoginService;
@@ -8,6 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.NoSuchElementException;
+
+import static com.linkode.api_server.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_MEMBER;
 
 @RestController
 @Slf4j
@@ -22,7 +27,11 @@ public class LoginController {
     @GetMapping("/oauth2/redirect")
     public BaseResponse<LoginResponse> githubLogin(@RequestParam String code) {
         log.info("[MemberController.githubLogin]");
-        return new BaseResponse<>(loginService.githubLogin(code));
+        try {
+            return new BaseResponse<>(loginService.githubLogin(code));
+        }catch (NoSuchElementException e){
+            return new BaseResponse<>(NOT_FOUND_MEMBER,null);
+        }
     }
 
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 기존에 member 객체가 없으면 예외를 터트리고 반환했는데, 예외가 아니라 컨트롤러에서 try catch 로 NoSuchElementException 이 터지면 따로 반환하도록 수정하였습니다.

## 🔑 변경 사항 (Key Changes)

- 컨트롤러에서 예외를 잡고 다르게 반환하도록 수정하였습니다.
- 컨트롤러에서 null 에 대한 예외를 잡기 때문에 서비스에서 member 객체가 null 인지 아닌지에 대해 구분할 필요가 없어졌습니다. 따라서 if 문 삭제하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [x] postman 에서 400 bad request 가 아니라 200 ok 로 잘 반환되는지
