### PR TITLE
Feat : memberStatus 를 추가로 반환 및 member 객체 null 에 대한 처리

### DIFF
--- a/src/main/java/com/linkode/api_server/controller/LoginController.java
+++ b/src/main/java/com/linkode/api_server/controller/LoginController.java
@@ -2,6 +2,7 @@ package com.linkode.api_server.controller;
 
 import com.linkode.api_server.common.exception.MemberException;
 import com.linkode.api_server.common.response.BaseResponse;
+import com.linkode.api_server.domain.Member;
 import com.linkode.api_server.dto.member.LoginResponse;
 import com.linkode.api_server.service.LoginService;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +28,13 @@ public class LoginController {
     @GetMapping("/oauth2/redirect")
     public BaseResponse<LoginResponse> githubLogin(@RequestParam String code) {
         log.info("[MemberController.githubLogin]");
-        try {
-            return new BaseResponse<>(loginService.githubLogin(code));
-        }catch (NoSuchElementException e){
-            return new BaseResponse<>(NOT_FOUND_MEMBER,null);
-        }
+//        try {
+//            return new BaseResponse<>(loginService.githubLogin(code));
+//        }catch (MemberEx e){
+//            return new BaseResponse<>(NOT_FOUND_MEMBER,null);
+//        }
+        return new BaseResponse<>(loginService.githubLogin(code));
+
     }
 
 }

--- a/src/main/java/com/linkode/api_server/dto/member/LoginResponse.java
+++ b/src/main/java/com/linkode/api_server/dto/member/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.linkode.api_server.dto.member;
 
 import com.linkode.api_server.domain.Member;
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class LoginResponse {
     /**
      * 깃허브 소셜로그인
      */
+    private boolean memberStatus;
     private Long memberId;
     private String githubId;
     private String accessToken;
@@ -45,13 +47,14 @@ public class LoginResponse {
     }
 
     // 정적 팩토리 메서드
-    public static LoginResponse of(Member member, String accessToken, String refreshToken, List<Studyroom> studyroomList) {
+    public static LoginResponse of(boolean memberStatus, @Nullable Member member, String githubId,String accessToken, String refreshToken, List<Studyroom> studyroomList) {
         return LoginResponse.builder()
-                .memberId(member.getMemberId())
-                .githubId(member.getGithubId())
+                .memberStatus(memberStatus)
+                .memberId(member != null ? member.getMemberId() : null)
+                .githubId(githubId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .profile(Profile.from(member))
+                .profile(member != null ? Profile.from(member) : null)
                 .studyroomList(studyroomList)
                 .build();
     }


### PR DESCRIPTION
## 요약 (Summary)
- [x] memberStatus 를 다시 추가해야해서 추가했습니다! 나머지 로직은 기존과 동일합니다.

## 🔑 변경 사항 (Key Changes)

- memberStatus 추가로 LoginResponse 수정이 이루어졌습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 데이터베이스에 없는 유저라도 memberStatus = false 라고 반환되며, githubId 만 유효한 값으로 반환되는지
- [x] 데이터베이스에 있는 유저라면 memberStatus = true 에 모든 값들이 채워져서 반환되는지
