### PR TITLE
Refactor : Member 테이블에 인덱스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,6 @@ repositories {
 
 dependencies {
 
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/linkode/api_server/domain/Member.java
+++ b/src/main/java/com/linkode/api_server/domain/Member.java
@@ -18,6 +18,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(indexes = {@Index(name="idx_github_id_status", columnList = "github_id, status")})
 public class Member extends BaseTime {
 
     @Id


### PR DESCRIPTION
## 요약 (Summary)
- [x] 코드 로직상 수정은 없습니다. 원래 로그인 관련 작업이 수행될 때에 github_id 로 데이터베이스를 순회했는데요! 지금은 데이터가 별로 없어서 큰 차이를 못느낄 수는 있으나, 후에 데이터가 많아지게 되면 full table scan 으로 실행시간이 길어질 듯 하여, 데이터베이스에 인덱스 작업 해두었습니다. 배포된 서버에 더미 데이터를 6백만개씩 넣을 순 없어서... 제가 로컬에서 테스트 해보았습니다. 제 블로그 첨부합니다!
[내 블로그 기록이지롱](https://jsilver720.tistory.com/32) 쿼리 실행 계획도 다 확인해보았습니다. 자세한 내용 블로그 참고 바랍니다

## 🔑 변경 사항 (Key Changes)

- 서버 데이터베이스에 인덱스 생성하였습니다.
